### PR TITLE
Update nameko to 2.13.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aio-pika==6.6.0
 aiotask-context==0.6.1
-nameko==2.12.0
+nameko==2.13.0


### PR DESCRIPTION
Nameko has released 2.13.0 so it would be helpful to have aio_nameko_proxy work with the latest (pre-3.0) nameko.

Also nameko-2.13.0 fixes a compatibility issue with the latest pytest releases.